### PR TITLE
fix(cmd): restore log-to-file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Global Flags:
       --http-proxy string   http://proxy-url:port (default: empty)
       --log-dir string      /path/to/log
       --log-json            output log as JSON
+      --log-to-file         output log to file
       --quiet               quiet mode (no output)
 
 Use "go-msfdb fetch [command] --help" for more information about a command.
@@ -83,6 +84,7 @@ Global Flags:
       --http-proxy string   http://proxy-url:port (default: empty)
       --log-dir string      /path/to/log
       --log-json            output log as JSON
+      --log-to-file         output log to file
       --quiet               quiet mode (no output)
 ```
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -29,6 +29,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.go-msfdb.yaml)")
 
+	RootCmd.PersistentFlags().Bool("log-to-file", false, "output log to file")
+	_ = viper.BindPFlag("log-to-file", RootCmd.PersistentFlags().Lookup("log-to-file"))
+
 	RootCmd.PersistentFlags().String("log-dir", "", "/path/to/log")
 	if err := viper.BindPFlag("log-dir", RootCmd.PersistentFlags().Lookup("log-dir")); err != nil {
 		panic(err)


### PR DESCRIPTION
# What did you implement:
Added `--log-to-file` option.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ go-msfdb fetch msfdb --log-to-file --log-dir "."
$ ls | grep go-msfdb.log
go-msfdb.log
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

