### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,44 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
-    #  misspell:
-    #ignore-words:
-    #  - Criterias
 
 linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
     - misspell
     - errcheck

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
 .PHONY: \
+	all \
 	build \
 	install \
-	all \
-	vendor \
+	lint \
 	vet \
 	fmt \
 	fmtcheck \
@@ -30,13 +30,17 @@ LDFLAGS := -X 'github.com/vulsio/go-msfdb/config.Version=$(VERSION)' \
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
-all: build
+all: build test
 
-build: main.go pretest fmt
+build: main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o go-msfdb $<
 
 install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"
+
+lint:
+	$(GO_OFF) get -u github.com/mgechev/revive
+	revive -config ./.revive.toml -formatter plain $(PKGS)
 
 vet:
 	echo $(PKGS) | xargs env $(GO) vet || exit;
@@ -47,7 +51,7 @@ fmt:
 fmtcheck:
 	$(foreach file,$(SRCS),gofmt -d $(file);)
 
-pretest: vet fmtcheck
+pretest: lint vet fmtcheck
 
 test: pretest
 	$(GO) test -cover -v ./... || exit;

--- a/commands/fetch-msfdb.go
+++ b/commands/fetch-msfdb.go
@@ -26,7 +26,7 @@ func init() {
 	fetchCmd.AddCommand(fetchMetasploitDBCmd)
 }
 
-func fetchMetasploitDB(cmd *cobra.Command, args []string) (err error) {
+func fetchMetasploitDB(_ *cobra.Command, _ []string) (err error) {
 	if err := utils.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/search.go
+++ b/commands/search.go
@@ -40,7 +40,7 @@ func init() {
 	}
 }
 
-func searchMetasploit(cmd *cobra.Command, args []string) (err error) {
+func searchMetasploit(_ *cobra.Command, _ []string) (err error) {
 	if err := utils.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -33,7 +33,7 @@ func init() {
 	}
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := utils.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -43,7 +43,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: logger.New(

--- a/db/redis.go
+++ b/db/redis.go
@@ -71,7 +71,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (bool, error) {
+func (r *RedisDriver) OpenDB(_, dbPath string, _ bool, option Option) (bool, error) {
 	return false, r.connectRedis(dbPath, option)
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -44,10 +44,7 @@ func FileWalk(root string, walkFn func(r io.Reader, path string) error) error {
 		}
 		defer f.Close()
 
-		if err = walkFn(f, path); err != nil {
-			return err
-		}
-		return nil
+		return walkFn(f, path)
 	})
 	if err != nil {
 		return xerrors.Errorf("error in file walk: %w", err)


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

