### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/commands/fetch-msfdb.go
+++ b/commands/fetch-msfdb.go
@@ -54,6 +54,11 @@ func fetchMetasploitDB(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	log15.Info("Fetching vulsio/msfdb-list")
 	gc := &git.Config{}
 	fc := fetcher.Config{
@@ -69,11 +74,6 @@ func fetchMetasploitDB(cmd *cobra.Command, args []string) (err error) {
 	log15.Info("Insert info into go-msfdb.", "db", driver.Name())
 	if err := driver.InsertMetasploit(records); err != nil {
 		log15.Error("Failed to insert.", "dbpath", viper.GetString("dbpath"), "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
 		return err
 	}
 


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

