### PR TITLE
breaking-change(redis): deprecated expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Available Commands:
   msfdb       Fetch the data of metasploit-framework cve's list
 
 Flags:
-      --expire uint   timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -h, --help          help for fetch
 
 Global Flags:

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -17,7 +17,4 @@ func init() {
 
 	fetchCmd.PersistentFlags().Int("batch-size", 50, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
-
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
-	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -194,7 +194,6 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 			if err := pipe.HSet(ctx, fmt.Sprintf(cveIDKeyFormat, record.CveID), hash, string(j)).Err(); err != nil {
 				return xerrors.Errorf("Failed to HSet CVE. err: %w", err)
 			}
-
 			if _, ok := newDeps[record.CveID]; !ok {
 				newDeps[record.CveID] = map[string]map[string]struct{}{}
 			}
@@ -208,7 +207,6 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 					if err := pipe.SAdd(ctx, fmt.Sprintf(edbIDKeyFormat, edb.ExploitUniqueID), member).Err(); err != nil {
 						return xerrors.Errorf("Failed to SAdd CVE. err: %w", err)
 					}
-
 					newDeps[record.CveID][hash][edb.ExploitUniqueID] = struct{}{}
 					if _, ok := oldDeps[record.CveID]; ok {
 						if _, ok := oldDeps[record.CveID][hash]; ok {


### PR DESCRIPTION
# What did you implement:
Expire was introduced to ensure safe operation in Redis, but since expire can only be set per key, it is not very useful for Sets and Hash.
Therefore, if there is any old content in each fetch, it will be deleted.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

