### PR TITLE
fix(redis): update Redis key relationship successfully

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -252,8 +252,10 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 					}
 				}
 			}
-			if err := pipe.HDel(ctx, fmt.Sprintf(cveIDKeyFormat, cveID), hash).Err(); err != nil {
-				return xerrors.Errorf("Failed to HDel. err: %w", err)
+			if _, ok := newDeps[cveID][hash]; !ok {
+				if err := pipe.HDel(ctx, fmt.Sprintf(cveIDKeyFormat, cveID), hash).Err(); err != nil {
+					return xerrors.Errorf("Failed to HDel. err: %w", err)
+				}
 			}
 		}
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -194,9 +194,7 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 			}
 
 			hash := fmt.Sprintf("%x", md5.Sum(j))
-			if err := pipe.HSet(ctx, fmt.Sprintf(cveIDKeyFormat, record.CveID), hash, string(j)).Err(); err != nil {
-				return xerrors.Errorf("Failed to HSet CVE. err: %w", err)
-			}
+			_ = pipe.HSet(ctx, fmt.Sprintf(cveIDKeyFormat, record.CveID), hash, string(j))
 			if _, ok := newDeps[record.CveID]; !ok {
 				newDeps[record.CveID] = map[string]map[string]struct{}{}
 			}
@@ -207,9 +205,7 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 			member := fmt.Sprintf(edbIDKeyMemberFormat, record.CveID, hash)
 			if len(record.Edbs) > 0 {
 				for _, edb := range record.Edbs {
-					if err := pipe.SAdd(ctx, fmt.Sprintf(edbIDKeyFormat, edb.ExploitUniqueID), member).Err(); err != nil {
-						return xerrors.Errorf("Failed to SAdd CVE. err: %w", err)
-					}
+					_ = pipe.SAdd(ctx, fmt.Sprintf(edbIDKeyFormat, edb.ExploitUniqueID), member)
 					newDeps[record.CveID][hash][edb.ExploitUniqueID] = struct{}{}
 					if _, ok := oldDeps[record.CveID]; ok {
 						if _, ok := oldDeps[record.CveID][hash]; ok {
@@ -247,15 +243,11 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 		for hash, edbs := range hashes {
 			for edb := range edbs {
 				if edb != "" {
-					if err := pipe.SRem(ctx, fmt.Sprintf(edbIDKeyFormat, edb), fmt.Sprintf(edbIDKeyMemberFormat, cveID, hash)).Err(); err != nil {
-						return xerrors.Errorf("Failed to SRem. err: %w", err)
-					}
+					_ = pipe.SRem(ctx, fmt.Sprintf(edbIDKeyFormat, edb), fmt.Sprintf(edbIDKeyMemberFormat, cveID, hash))
 				}
 			}
 			if _, ok := newDeps[cveID][hash]; !ok {
-				if err := pipe.HDel(ctx, fmt.Sprintf(cveIDKeyFormat, cveID), hash).Err(); err != nil {
-					return xerrors.Errorf("Failed to HDel. err: %w", err)
-				}
+				_ = pipe.HDel(ctx, fmt.Sprintf(cveIDKeyFormat, cveID), hash)
 			}
 		}
 	}
@@ -263,9 +255,7 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 	if err != nil {
 		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
-	if err := pipe.Set(ctx, depKey, string(newDepsJSON), 0).Err(); err != nil {
-		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
-	}
+	_ = pipe.Set(ctx, depKey, string(newDepsJSON), 0)
 	if _, err := pipe.Exec(ctx); err != nil {
 		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:
There was a bug in the update method of deleting outdated information in the DB at the time of Redis fetch, causing more information than necessary to be deleted.This bug has been fixed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## master
```console
$ go-msfdb fetch msfdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET MSF#CVE#CVE-1999-1510 edcc74340a1e2c0c362a63e94ad4ba42
"{\"Name\":\"bison_ftp_bof.rb\",\"Title\":\"BisonWare BisonFTP Server Buffer Overflow\",\"Description\":\"BisonWare BisonFTP Server 3.5 is prone to an overflow condition. This module exploits a buffer overflow vulnerability in the said application.\",\"CveID\":\"CVE-1999-1510\",\"Edbs\":[{\"ExploitUniqueID\":\"EDB-17649\"}],\"References\":[{\"Link\":\"http://www.securityfocus.com/bid/49109\"},{\"Link\":\"http://secpod.org/msf/bison_server_bof.rb\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/ftp/bison_ftp_bof.rb\"}]}"
127.0.0.1:6379> SET MSF#DEP '{"CVE-1999-1510": {"edcc74340a1e2c0c362a63e94ad4ba42": {"EDB-17649": {}, "test": {}}}}'
OK

$ go-msfdb fetch msfdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET MSF#CVE#CVE-1999-1510 edcc74340a1e2c0c362a63e94ad4ba42
(nil) // bug
127.0.0.1:6379> HEXISTS MSF#CVE#CVE-1999-1510 edcc74340a1e2c0c362a63e94ad4ba425D5D
(integer) 0
```

## MaineK00n/fix-update-deps
```console
$ go-msfdb fetch msfdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET MSF#CVE#CVE-1999-1510 edcc74340a1e2c0c362a63e94ad4ba42
"{\"Name\":\"bison_ftp_bof.rb\",\"Title\":\"BisonWare BisonFTP Server Buffer Overflow\",\"Description\":\"BisonWare BisonFTP Server 3.5 is prone to an overflow condition. This module exploits a buffer overflow vulnerability in the said application.\",\"CveID\":\"CVE-1999-1510\",\"Edbs\":[{\"ExploitUniqueID\":\"EDB-17649\"}],\"References\":[{\"Link\":\"http://www.securityfocus.com/bid/49109\"},{\"Link\":\"http://secpod.org/msf/bison_server_bof.rb\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/ftp/bison_ftp_bof.rb\"}]}"
127.0.0.1:6379> SET MSF#DEP '{"CVE-1999-1510": {"edcc74340a1e2c0c362a63e94ad4ba42": {"EDB-17649": {}, "test": {}}}}'
OK

$ go-msfdb fetch msfdb --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET MSF#CVE#CVE-1999-1510 edcc74340a1e2c0c362a63e94ad4ba42
"{\"Name\":\"bison_ftp_bof.rb\",\"Title\":\"BisonWare BisonFTP Server Buffer Overflow\",\"Description\":\"BisonWare BisonFTP Server 3.5 is prone to an overflow condition. This module exploits a buffer overflow vulnerability in the said application.\",\"CveID\":\"CVE-1999-1510\",\"Edbs\":[{\"ExploitUniqueID\":\"EDB-17649\"}],\"References\":[{\"Link\":\"http://www.securityfocus.com/bid/49109\"},{\"Link\":\"http://secpod.org/msf/bison_server_bof.rb\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/ftp/bison_ftp_bof.rb\"}]}"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

